### PR TITLE
Change the setup slightly:

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,6 @@
 # Required for pnpm deploy
-inject-workspace-packages=true
+# inject-workspace-packages=true
+force-legacy-deploy=true
 
 # Use the buggy pnpm@10.6.3 version.
 manage-package-manager-versions=true

--- a/packages/c/package.json
+++ b/packages/c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scope/c",
   "dependencies": {
-    "@scope/d": "workspace:*"
+    "@scope/d": "workspace:../d/dist"
   }
 }

--- a/packages/d/package.json
+++ b/packages/d/package.json
@@ -1,3 +1,7 @@
 {
-  "name": "@scope/d"
+  "name": "@scope/d",
+  "scripts": {
+    "build": "mkdir ./dist && touch dist/output.txt",
+    "clean": "rm -rf ./dist"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
   packages/c:
     dependencies:
       '@scope/d':
-        specifier: workspace:*
-        version: link:../d
+        specifier: workspace:../d/dist
+        version: link:../d/dist
 
   packages/d: {}


### PR DESCRIPTION
  * use a relative workspace link to reference d from c
  * add force-legacy-deploy


Thanks for creating the original repro @gluxon ! I altered it to better reflect the setup where I got the issue. The main thing seems to be the force-legacy-deploy=true in the .npmrc, so the bug might be a bit different than I thought initially, still, this works in 10.6.2 but not in 10.6.3.